### PR TITLE
replace emptycodelist.csv with documentType.csv and add codes

### DIFF
--- a/codelists/documentType.csv
+++ b/codelists/documentType.csv
@@ -1,5 +1,5 @@
 Category,Code,Title_en,Description_en,Source
 ,tariffs,Tariffs,For providing tariff and pricing schedules.,
 ,tariffMethod,Tariff Method,For summarising the method by which tariffs are set and linking to detailed documentation of the methods for setting tariffs. This may include written documentation and spreadsheets providing the models used to calculate tariffs.,
-,tariffReview,Tariff Review,For summarising the arrangements for the review and regulation of tariffs and linking to detailed documentation that covers how tariffs are regulated. This is important to explain to users why they are paying what they are paying and the scope for changes to payment structures.
+,tariffReview,Tariff Review,For summarising the arrangements for the review and regulation of tariffs and linking to detailed documentation that covers how tariffs are regulated. This is important to explain to users why they are paying what they are paying and the scope for changes to payment structures.,
 ,tariffIllustration,Tariff Illustration,For linking to graphs and reports on the change over time in tariff prices. Use the relevant image media type when linking to PNG or JPEG or GIF graphs to allow applications to directly display this content.,

--- a/codelists/documentType.csv
+++ b/codelists/documentType.csv
@@ -1,0 +1,5 @@
+Category,Code,Title_en,Description_en,Source
+,tariffs,Tariffs,For providing tariff and pricing schedules.,
+,tariffMethod,Tariff Method,For summarising the method by which tariffs are set and linking to detailed documentation of the methods for setting tariffs. This may include written documentation and spreadsheets providing the models used to calculate tariffs.,
+,tariffReview,Tariff Review,For summarising the arrangements for the review and regulation of tariffs and linking to detailed documentation that covers how tariffs are regulated. This is important to explain to users why they are paying what they are paying and the scope for changes to payment structures.
+,tariffIllustration,Tariff Illustration,For linking to graphs and reports on the change over time in tariff prices. Use the relevant image media type when linking to PNG or JPEG or GIF graphs to allow applications to directly display this content.,

--- a/codelists/emptyCodelist.csv
+++ b/codelists/emptyCodelist.csv
@@ -1,1 +1,0 @@
-Category,Code,Title_en,Description_en,Source


### PR DESCRIPTION
The additional codes referenced in the readme were not documented in a codelists directory - this was causing an ```emptycodelist.csv``` file to be pulled into the ppp extension